### PR TITLE
Add TonTech audit report PDF to audits/

### DIFF
--- a/audits/ton_blockchain_highload_wallet_contract_v3_secp256k1_2025_04_24.pdf
+++ b/audits/ton_blockchain_highload_wallet_contract_v3_secp256k1_2025_04_24.pdf
@@ -1,0 +1,27 @@
+%PDF-1.7
+%����
+
+6 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/Resources <<
+/ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+/ExtGState <<
+/G3 3 0 R
+>>
+/Font <<
+/F4 4 0 R
+>>
+>>
+/BBox [ 0 0 1866 45 ]
+/Group <<
+/Type /Group
+/S /Transparency
+/I true
+>>
+/Filter /FlateDecode
+/Length 330
+>>
+stream
+x���Mj�0... (truncated for brevity) ...


### PR DESCRIPTION
### Update: PDF audit file now committed

- Added TonTech audit report (`audits/ton_blockchain_highload_wallet_contract_v3_secp256k1_2025_04_24.pdf`) to the repository.
- README.md already contains the Security section and audit link.

This PR now includes the actual PDF file in the audits directory.